### PR TITLE
WIP: Support for curvilinear coordinates

### DIFF
--- a/src/Contour.jl
+++ b/src/Contour.jl
@@ -260,8 +260,8 @@ function interpolate(x::AbstractMatrix{T}, y::AbstractMatrix{T}, z::AbstractMatr
         x_interp = x[xi,yi+1] + Δ[2]
     elseif edge == S
         Δ = [y[xi+1,yi  ] - y[xi,  yi  ], x[xi+1,yi  ] - x[xi,  yi  ]].*(h - z[xi,  yi  ])/(z[xi+1,yi  ] - z[xi,  yi  ])
-        y_interp = y[xi+1,yi] + Δ[1]
-        x_interp = x[xi+1,yi] + Δ[2]
+        y_interp = y[xi,yi] + Δ[1]
+        x_interp = x[xi,yi] + Δ[2]
     end
 
     return x_interp, y_interp

--- a/src/Contour.jl
+++ b/src/Contour.jl
@@ -226,7 +226,7 @@ end
 # Given the row and column indices of the lower left
 # vertex, add the location where the contour level
 # crosses the specified edge.
-function interpolate(x, y, z::AbstractMatrix{T}, h::Number, xi::Int, yi::Int, edge::UInt8) where {T <: AbstractFloat}
+function interpolate(x::AbstractVector{T}, y::AbstractVector{T}, z::AbstractMatrix{T}, h::Number, xi::Int, yi::Int, edge::UInt8) where {T <: AbstractFloat}
     if edge == W
         y_interp = y[yi] + (y[yi + 1] - y[yi]) * (h - z[xi, yi]) / (z[xi, yi + 1] - z[xi, yi])
         x_interp = x[xi]
@@ -243,6 +243,30 @@ function interpolate(x, y, z::AbstractMatrix{T}, h::Number, xi::Int, yi::Int, ed
 
     return x_interp, y_interp
 end
+
+
+function interpolate(x::AbstractMatrix{T}, y::AbstractMatrix{T}, z::AbstractMatrix{T}, h::Number, xi::Int, yi::Int, edge::UInt8) where {T <: AbstractFloat}
+    if edge == W
+        Δ = [y[xi,  yi+1] - y[xi,  yi  ], x[xi,  yi+1] - x[xi,  yi  ]].*(h - z[xi,  yi  ])/(z[xi,  yi+1] - z[xi,  yi  ])
+        y_interp = y[xi,yi] + Δ[1]
+        x_interp = x[xi,yi] + Δ[2]
+    elseif edge == E
+        Δ = [y[xi+1,yi+1] - y[xi+1,yi  ], x[xi+1,yi+1] - x[xi+1,yi  ]].*(h - z[xi+1,yi  ])/(z[xi+1,yi+1] - z[xi+1,yi  ])
+        y_interp = y[xi+1,yi] + Δ[1]
+        x_interp = x[xi+1,yi] + Δ[2]
+    elseif edge == N
+        Δ = [y[xi+1,yi+1] - y[xi,  yi+1], x[xi+1,yi+1] - x[xi,  yi+1]].*(h - z[xi,  yi+1])/(z[xi+1,yi+1] - z[xi,  yi+1])
+        y_interp = y[xi,yi+1] + Δ[1]
+        x_interp = x[xi,yi+1] + Δ[2]
+    elseif edge == S
+        Δ = [y[xi+1,yi  ] - y[xi,  yi  ], x[xi+1,yi  ] - x[xi,  yi  ]].*(h - z[xi,  yi  ])/(z[xi+1,yi  ] - z[xi,  yi  ])
+        y_interp = y[xi+1,yi] + Δ[1]
+        x_interp = x[xi+1,yi] + Δ[2]
+    end
+
+    return x_interp, y_interp
+end
+
 
 # Given a cell and a starting edge, we follow the contour line until we either
 # hit the boundary of the input data, or we form a closed contour.

--- a/src/Contour.jl
+++ b/src/Contour.jl
@@ -244,7 +244,6 @@ function interpolate(x::AbstractVector{T}, y::AbstractVector{T}, z::AbstractMatr
     return x_interp, y_interp
 end
 
-
 function interpolate(x::AbstractMatrix{T}, y::AbstractMatrix{T}, z::AbstractMatrix{T}, h::Number, xi::Int, yi::Int, edge::UInt8) where {T <: AbstractFloat}
     if edge == W
         Δ = [y[xi,  yi+1] - y[xi,  yi  ], x[xi,  yi+1] - x[xi,  yi  ]].*(h - z[xi,  yi  ])/(z[xi,  yi+1] - z[xi,  yi  ])

--- a/test/verify_vertices.jl
+++ b/test/verify_vertices.jl
@@ -112,8 +112,8 @@ for line in lines
 end
 
 # Test curvilinear coordinates
-θ = range(0.0, 2π,length=100)
-R = range(1.0, 3.0, length=100)
+θ = range(0.0, stop=2π,length=100)
+R = range(1.0, stop=2.0, length=100)
 ζ = ComplexF64[r*exp(im*ϕ) for ϕ in θ, r in R]
 x, y, z = real.(ζ), imag.(ζ), abs.(ζ)
 

--- a/test/verify_vertices.jl
+++ b/test/verify_vertices.jl
@@ -112,10 +112,10 @@ for line in lines
 end
 
 # Test curvilinear coordinates
-θ = range(0, 2π,length=100)
-R = range(1, 3, length=100)
+θ = range(0.0, 2π,length=100)
+R = range(1.0, 3.0, length=100)
 ζ = ComplexF64[r*exp(im*ϕ) for ϕ in θ, r in R]
-x, y, z = real(ζ), imag(ζ), abs.(ζ)
+x, y, z = real.(ζ), imag.(ζ), abs.(ζ)
 
 h = 1 + rand()
 xs, ys = coordinates(contour(x, y, z, h).lines[1])

--- a/test/verify_vertices.jl
+++ b/test/verify_vertices.jl
@@ -111,6 +111,17 @@ for line in lines
     @test d[2] / d[1] ≈ -1.0
 end
 
+# Test curvilinear coordinates
+θ = range(0, 2π,length=100)
+R = range(1, 3, length=100)
+ζ = ComplexF64[r*exp(im*ϕ) for ϕ in θ, r in R]
+x, y, z = real(ζ), imag(ζ), abs.(ζ)
+
+h = 1 + rand()
+xs, ys = coordinates(contour(x, y, z, h).lines[1])
+
+@test all(xs.^2 + ys.^2 .≈ h^2)
+
 # Test Known Bugs
 
 # Issue #12


### PR DESCRIPTION
It almost works! 

``` julia
θ = linspace(0,2π,10)
R = linspace(1,3, 10)
ζ = Complex128[r*exp(im*ϕ) for ϕ in θ, r in R]
x, y, z = real(ζ), imag(ζ), abs(ζ)
```

so `z` has the form

```
10x10 Array{Float64,2}:
 1.0  1.22222  1.44444  1.66667  1.88889  2.11111  2.33333  2.55556  2.77778  3.0
 1.0  1.22222  1.44444  1.66667  1.88889  2.11111  2.33333  2.55556  2.77778  3.0
 1.0  1.22222  1.44444  1.66667  1.88889  2.11111  2.33333  2.55556  2.77778  3.0
 1.0  1.22222  1.44444  1.66667  1.88889  2.11111  2.33333  2.55556  2.77778  3.0
 1.0  1.22222  1.44444  1.66667  1.88889  2.11111  2.33333  2.55556  2.77778  3.0
 1.0  1.22222  1.44444  1.66667  1.88889  2.11111  2.33333  2.55556  2.77778  3.0
 1.0  1.22222  1.44444  1.66667  1.88889  2.11111  2.33333  2.55556  2.77778  3.0
 1.0  1.22222  1.44444  1.66667  1.88889  2.11111  2.33333  2.55556  2.77778  3.0
 1.0  1.22222  1.44444  1.66667  1.88889  2.11111  2.33333  2.55556  2.77778  3.0
 1.0  1.22222  1.44444  1.66667  1.88889  2.11111  2.33333  2.55556  2.77778  3.0
```

which would look like straight lines if plotted in rectangular coordinates.  But if the matrices `x` and `y` that contain the coordinate points are passed in, we get

![circles](https://cloud.githubusercontent.com/assets/7328215/4958451/f9a2fb3a-66ae-11e4-8a16-3ca74b5dd92a.png)

There are still a few kinks to work out though.  For example:

``` julia
θ = linspace(0,2π,100);
R = linspace(1,2, 50);
ζ = Complex128[r*exp(im*ϕ) for ϕ in θ, r in R];
x, y = real(ζ), imag(ζ);
z = imag(ζ .+ conj(1./ζ));
```

results in

![cylinder](https://cloud.githubusercontent.com/assets/7328215/4958452/faafdcb4-66ae-11e4-9744-335f96b8f40e.png)
