### PR TITLE
Fixes for v0.7.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ sudo: false
 os:
   - linux
 julia:
-  - 0.6
+  - 0.7
   - nightly
 notifications:
   - email: false

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,3 +1,2 @@
-julia 0.6
-Compat 0.9.4
+julia 0.7-beta
 StaticArrays

--- a/src/Contour.jl
+++ b/src/Contour.jl
@@ -100,7 +100,7 @@ levels to trace.
 function contourlevels(z, n)
     zmin, zmax = extrema(z)
     dz = (zmax - zmin) / (n + 1)
-    range(zmin + dz, dz, n)
+    range(zmin + dz; step = dz, length = n)
 end
 
 """
@@ -109,8 +109,8 @@ a tuple of lists.
 """
 function coordinates(c::Curve2{T}) where {T}
     N = length(c.vertices)
-    xlist = Vector{T}(N)
-    ylist = Vector{T}(N)
+    xlist = Vector{T}(undef, N)
+    ylist = Vector{T}(undef, N)
 
     for (i, v) in enumerate(c.vertices)
         xlist[i] = v[1]
@@ -221,14 +221,14 @@ function add_vertex!(curve::Curve2{T}, pos::(Tuple{T,T}), dir::UInt8) where {T}
     if dir == fwd
         push!(curve.vertices, SVector{2,T}(pos...))
     else
-        unshift!(curve.vertices, SVector{2,T}(pos...))
+        pushfirst!(curve.vertices, SVector{2,T}(pos...))
     end
 end
 
 # Given the row and column indices of the lower left
 # vertex, add the location where the contour level
 # crosses the specified edge.
-function interpolate(x, y, z::Matrix{T}, h::Number, xi::Int, yi::Int, edge::UInt8) where {T <: AbstractFloat}
+function interpolate(x, y, z::AbstractMatrix{T}, h::Number, xi::Int, yi::Int, edge::UInt8) where {T <: AbstractFloat}
     if edge == W
         y_interp = y[yi] + (y[yi + 1] - y[yi]) * (h - z[xi, yi]) / (z[xi, yi + 1] - z[xi, yi])
         x_interp = x[xi]

--- a/test/interface.jl
+++ b/test/interface.jl
@@ -1,6 +1,6 @@
 module InterfaceTests
 
-using Contour, Base.Test
+using Contour, Test
 
 function setup()
     nx, ny = 10, 10

--- a/test/verify_vertices.jl
+++ b/test/verify_vertices.jl
@@ -1,14 +1,16 @@
 module VerticesTests
 
-using Contour, Base.Test
+using Contour, Test
+using Base.MathConstants: π, φ
+using LinearAlgebra: Diagonal
 
 # Setup test axes that will be shared among the tests
 
 # Shift the axes so that they do not line up with
 # integer values
 Δ = 0.01
-X = collect(0:Δ:4) + π
-Y = collect(0:Δ:3) + φ
+X = collect(0:Δ:4) .+ π
+Y = collect(0:Δ:3) .+ φ
 
 # TEST CASE 1
 #
@@ -61,8 +63,8 @@ lines = Contour.contour(X, Y, Z, h).lines
 
 for line in lines
     @test length(line.vertices) == 2
-    Δ = line.vertices[2] - line.vertices[1]
-    @test Δ[2] / Δ[1] ≈ -1.0
+    d = line.vertices[2] - line.vertices[1]
+    @test d[2] / d[1] ≈ -1.0
 end
 
 # Case 5: z_center < h
@@ -76,8 +78,8 @@ lines = Contour.contour(X, Y, Z, h).lines
 
 for line in lines
     @test length(line.vertices) == 2
-    Δ = line.vertices[2] - line.vertices[1]
-    @test Δ[2] / Δ[1] ≈ 1.0
+    d = line.vertices[2] - line.vertices[1]
+    @test d[2] / d[1] ≈ 1.0
 end
 
 # Case 10: z_center > h
@@ -90,8 +92,8 @@ lines = Contour.contour(X, Y, Z, h).lines
 
 for line in lines
     @test length(line.vertices) == 2
-    Δ = line.vertices[2] - line.vertices[1]
-    @test Δ[2] / Δ[1] ≈ 1.0
+    d = line.vertices[2] - line.vertices[1]
+    @test d[2] / d[1] ≈ 1.0
 end
 
 # Case 10: z_center < h
@@ -105,8 +107,8 @@ lines = Contour.contour(X, Y, Z, h).lines
 
 for line in lines
     @test length(line.vertices) == 2
-    Δ = line.vertices[2] - line.vertices[1]
-    @test Δ[2] / Δ[1] ≈ -1.0
+    d = line.vertices[2] - line.vertices[1]
+    @test d[2] / d[1] ≈ -1.0
 end
 
 # Test Known Bugs
@@ -114,7 +116,7 @@ end
 # Issue #12
 x = float(collect(1:3));
 y = copy(x);
-z = eye(3, 3);
+z = Diagonal(ones(3));
 contours(x, y, z)
 
 # Test handling of saddle points


### PR DESCRIPTION
1. require julia v0.7 beta, drop Compat as it was not used anywhere.

2. fix deprecations (range, pushfirst!, math constants, eye)

3. make interpolate use a z::AbstractMatrix, since it does not modify
z and should work fine

4. in test loops, use d instead of overwriting global Δ, to avoid the
warning

5. broadcast + to avoid the warning