### PR TITLE
Remove imports which are no longer available in v1.0.

### DIFF
--- a/src/Contour.jl
+++ b/src/Contour.jl
@@ -14,7 +14,7 @@ export
     lines,
     coordinates
 
-import Base: push!, start, next, done, length, eltype, show
+import Base: push!, length, eltype, show
 
 struct Curve2{T}
     vertices::Vector{SVector{2,T}}


### PR DESCRIPTION
Apparently they were not used anyway.