### PR TITLE
Use arrays rather than Dicts for Contour Chasing

### DIFF
--- a/src/Contour.jl
+++ b/src/Contour.jl
@@ -205,7 +205,7 @@ end
 function get_level_cells(z, h::Number)
 
     xi_max, yi_max = size(z)
-    cells = fill(0x0, (xi_max-1,yi_max-1))
+    cells = zeros(UInt8, (xi_max-1,yi_max-1))
 
     cell_pop = 0
 
@@ -242,6 +242,14 @@ function get_level_cells(z, h::Number)
     end
 
     return cells, cell_pop
+end
+
+function findfirst_cell(m, from_x, from_y)
+    s = size(m)
+    for xi = from_x:s[1], yi = from_y:s[2]
+        !iszero(m[xi,yi]) && return xi,yi
+    end
+    return 0,0
 end
 
 # Some constants used by trace_contour
@@ -350,13 +358,14 @@ function trace_contour(x, y, z, h::Number, cells::Array, cell_pop)
     # It then tries to trace the contour in the opposite direction.
 
     nonempty_cells = cell_pop
+    (xi_0, yi_0) = (1,1)
 
     while nonempty_cells > 0
         contour = Curve2(promote_type(map(eltype, (x, y, z))...))
 
         # Pick initial box
-        ind = findfirst(!iszero, cells)
-        (xi_0, yi_0) = (ind[1], ind[2])
+        (xi_0, yi_0) = findfirst_cell(cells, xi_0, yi_0)
+        iszero(xi_0) && iszero(yi_0) && break
         (xi, yi) = (xi_0, yi_0)
         cell = cells[xi,yi]
 


### PR DESCRIPTION
This builds on #50. Inspired by: https://www.researchgate.net/publication/282975362_Flying_Edges_A_High-Performance_Scalable_Isocontouring_Algorithm

This could serve as a basis for that implementation, which should yield even better performance once fully implemented.

The basic idea is to store each case in a 2D Matrix and loop through this matrix (once). Since the matrix is all UInt8, it ends up very compact in memory. We also avoid hashing overhead and do not need to store keys. Since we track the number of non-zero elements for large arrays, sparse contours (such as one closed loop) should still perform better than the dictionary approach, though they may require more memory allocations. 

For reference:
v0.5.1:
```
contour
1-element BenchmarkTools.BenchmarkGroup:
  tags: []
  "testdata" => BenchmarkTools.Trial: 
	  memory estimate:  3.14 MiB
	  allocs estimate:  31197
	  --------------
	  minimum time:     2.951 ms (0.00% GC)
	  median time:      3.283 ms (0.00% GC)
	  mean time:        3.464 ms (3.25% GC)
	  maximum time:     7.878 ms (0.00% GC)
	  --------------
	  samples:          1438
	  evals/sample:     1

```

This PR:
```
contour
1-element BenchmarkTools.BenchmarkGroup:
  tags: []
  "testdata" => BenchmarkTools.Trial: 
	  memory estimate:  569.73 KiB
	  allocs estimate:  370
	  --------------
	  minimum time:     911.743 μs (0.00% GC)
	  median time:      1.029 ms (0.00% GC)
	  mean time:        1.068 ms (1.40% GC)
	  maximum time:     2.901 ms (58.94% GC)
	  --------------
	  samples:          4662
	  evals/sample:     1
```