### PR TITLE
Add the accessor `vertices` to the API.

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -18,7 +18,6 @@ jobs:
           - '1.0'
           - '1.6'
           - '1' # latest stable version
-          - 'nightly'
         os:
           - ubuntu-latest
           #- macOS-latest

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -17,6 +17,7 @@ jobs:
         version:
           - '1.0'
           - '1.6'
+          - '1' # latest stable version
           - 'nightly'
         os:
           - ubuntu-latest

--- a/Project.toml
+++ b/Project.toml
@@ -4,6 +4,13 @@ version = "0.6.2"
 
 [compat]
 julia = "0.7, 1"
+Aqua = "0.8"
+JET = "0.8"
+LinearAlgebra = "1"
+OffsetArrays = "1"
+StaticArrays = "1"
+StatsBase = "0.34"
+Test = "1"
 
 [extras]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"

--- a/Project.toml
+++ b/Project.toml
@@ -5,7 +5,7 @@ version = "0.6.2"
 [compat]
 julia = "0.7, 1"
 Aqua = "0.8"
-JET = "0.01, 0.4, 0.8"
+JET = "0.0.1, 0.4, 0.8"
 LinearAlgebra = "1"
 OffsetArrays = "1"
 StaticArrays = "1"

--- a/Project.toml
+++ b/Project.toml
@@ -5,7 +5,7 @@ version = "0.6.2"
 [compat]
 julia = "0.7, 1"
 Aqua = "0.8"
-JET = "0.8"
+JET = "0.01, 0.4, 0.8"
 LinearAlgebra = "1"
 OffsetArrays = "1"
 StaticArrays = "1"

--- a/docs/src/reference.md
+++ b/docs/src/reference.md
@@ -12,6 +12,7 @@ level
 levels
 lines
 coordinates
+vertices
 ```
 
 # Utilities

--- a/docs/src/tutorial.md
+++ b/docs/src/tutorial.md
@@ -97,8 +97,8 @@ This contour level only had one line. An isoline is represented as a sequence of
 vertices, which either starts and ends at the boundaries of the data set, or
 closes on itself, in which case the first and last points are equal.
 
-The ``x``- and ``y``-coordinates of an isoline are extracted using the
-[`coordinates`](@ref) function:
+The ``x``- and ``y``-coordinates of an isoline can be extracted using the
+[`coordinates`](@ref) or [`vertices`](@ref) functions:
 
 ```@example
 using Contour # hide
@@ -109,6 +109,7 @@ c = contours(x,y,z) # hide
 cl = first(levels(c)) # hide
 l = first(lines(cl))
 xs, ys = coordinates(l)
+x_y_pairs = vertices(l)
 nothing # hide
 ```
 

--- a/src/Contour.jl
+++ b/src/Contour.jl
@@ -10,7 +10,8 @@ export
     level,
     levels,
     lines,
-    coordinates
+    coordinates,
+    vertices
 
 import Base: push!, length, eltype, show
 
@@ -36,7 +37,7 @@ show(io::IO, ::MIME"text/plain", cl::ContourLevel) = write(io, "$(typeof(cl))\n 
 show(io::IO, ::MIME"text/plain", cls::Vector{ContourLevel{T}}) where {T} = write(io, "$(typeof(cls))\n  $(length(cls)) contour level(s)")
 """
 `lines(c)` Extracts an iterable collection of isolines from a contour level.
-Use [`coordinates`](@ref) to get the coordinates of a line.
+Use [`coordinates`](@ref) or [`vertices`](@ref) to get the coordinates of a line.
 """
 lines(cl::ContourLevel) = cl.lines
 """
@@ -53,8 +54,8 @@ show(io::IO, ::MIME"text/plain", cc::ContourCollection) = write(io, "$(typeof(cc
 
 """
 Turns the output of [`contours`](@ref) into an iterable with each of the traced
-contour levels. Each of the objects support [`level`](@ref) and
-[`coordinates`](@ref).
+contour levels. Each of the objects support [`level`](@ref),
+[`coordinates`](@ref), and [`vertices`](@ref).
 """
 levels(cc::ContourCollection) = cc.contours
 
@@ -134,6 +135,13 @@ function coordinates(c::Curve2{T}) where {T}
     end
     xlist, ylist
 end
+
+"""
+`vertices(c)`
+
+Returns the vertices of a contour line as a vector of 2-element tuples.
+"""
+vertices(c::Curve2) = c.vertices
 
 # The marching squares algorithm defines 16 cell types
 # based on the edges that a contour line enters and exits

--- a/test/interface.jl
+++ b/test/interface.jl
@@ -19,6 +19,8 @@ for c in levels(cs)
     for l in lines(c)
         x, y = coordinates(l)
         @assert typeof(x) == typeof(y) == Vector{Float64}
+        xy = vertices(l)
+        @test xy isa Vector{Tuple{Float64,Float64}}
     end
 end
 


### PR DESCRIPTION
This allows the user to access this field of `Curve2D` objects directly, without allocations.

- add a basic test
- add to docs
- incidental change: add compat for testing packages (otherwise Aqua complains on Julia 1.10)
- incidental change: add 1 and remove nightly from CI